### PR TITLE
Fix JSON in VSCode.json shortcuts file

### DIFF
--- a/Hotkeys/Shortcuts/Code/VSCode.json
+++ b/Hotkeys/Shortcuts/Code/VSCode.json
@@ -274,3 +274,5 @@
     "description": "Insert cursor below / above",
     "keywords": ["cursor", "multi"],
     "category": "Multi-cursor"
+  }
+]


### PR DESCRIPTION
On Windows after installing the plugin using `ptr`, the VSCode shortcuts didn't show. I found that the JSON file for it is incomplete.

The object starting here is never closed:
https://github.com/ruslanlap/PowerToysRun-Hotkeys/blob/cb3d729090792de3bebdd1272ed9f5d2ca542d71/Hotkeys/Shortcuts/Code/VSCode.json#L272-L276

This PR fixes the existing JSON. But I'm wondering if shortcuts were cut off at the end here.

Btw, I love this plugin! Much better than the text file I was keeping :-).